### PR TITLE
make reuseport compile on netbsd

### DIFF
--- a/poll/poll_bsd.go
+++ b/poll/poll_bsd.go
@@ -25,9 +25,6 @@ func New(fd int) (p *Poller, err error) {
 		Ident:  uint64(fd),
 		Filter: unix.EVFILT_WRITE,
 		Flags:  unix.EV_ADD | unix.EV_ENABLE | unix.EV_ONESHOT,
-		Fflags: 0,
-		Data:   0,
-		Udata:  nil,
 	}
 	return p, nil
 }


### PR DESCRIPTION
Three's no need to explicitly initialize these fields anyways and netbsd uses a different type for the `Udate` field (int64).

fixes #14