### PR TITLE
Attempt to fix TravisCI OSX tests

### DIFF
--- a/.fixup-environment.sh
+++ b/.fixup-environment.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -ex
+
+if [[ $TRAVIS_OS_NAME == "linux" ]]; then
+	sysctl -w net.ipv6.conf.lo.disable_ipv6=0
+	sysctl -w net.ipv6.conf.default.disable_ipv6=0
+	sysctl -w net.ipv6.conf.all.disable_ipv6=0;
+else
+	cat > /Library/LaunchDaemons/limit.maxfiles.plist << EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>limit.maxfiles</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>launchctl</string>
+      <string>limit</string>
+      <string>maxfiles</string>
+      <string>65535</string>
+      <string>65535</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>ServiceIPC</key>
+    <false/>
+  </dict>
+</plist>
+EOF
+	chown root:wheel /Library/LaunchDaemons/limit.maxfiles.plist
+	launchctl load -w /Library/LaunchDaemons/limit.maxfiles.plist
+	launchctl limit maxfiles
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ install:
   - make deps
 
 script:
-  - sudo sysctl -w net.ipv6.conf.lo.disable_ipv6=0 net.ipv6.conf.default.disable_ipv6=0 net.ipv6.conf.all.disable_ipv6=0
-  - bash <(curl -s https://raw.githubusercontent.com/ipfs/ci-helpers/master/travis-ci/run-standard-tests.sh)
+  - sudo bash ./.fixup-environment.sh
+  - ulimit -n 4096; bash <(curl -s https://raw.githubusercontent.com/ipfs/ci-helpers/master/travis-ci/run-standard-tests.sh)
 
 cache:
   directories:


### PR DESCRIPTION
I created `.fixup-environment.sh` to handle setting up the running OS for the tests.
On linux it sets the sysctls to enable IPv6 support.
On OSX it ups the global file descriptor limit to 65535.

I then changed the file descriptor limit to 4096 while the tests are running.

I tested a minor variant of this fix on my fork, so hopefully it'll pass here.
https://travis-ci.org/Coderlane/go-reuseport/builds/325315301
  