### PR TITLE
Remove IPv6 enable from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ install:
   - make deps
 
 script:
-  - sudo sysctl -w net.ipv6.conf.lo.disable_ipv6=0 net.ipv6.conf.default.disable_ipv6=0 net.ipv6.conf.all.disable_ipv6=0
   - bash <(curl -s https://raw.githubusercontent.com/ipfs/ci-helpers/master/travis-ci/run-standard-tests.sh)
 
 cache:


### PR DESCRIPTION
This line breaks test on OSX and run-standard-tests.sh should now enable IPv6 on Linux TravisCI hosts. Thus this line can be safely removed.