### PR TITLE
detect dials to self

### DIFF
--- a/impl_unix.go
+++ b/impl_unix.go
@@ -177,6 +177,15 @@ func dial(ctx context.Context, dialer net.Dialer, netw, addr string) (c net.Conn
 		return nil, err
 	}
 
+	if rprotocol == unix.IPPROTO_TCP {
+		raddr := c.RemoteAddr().(*net.TCPAddr)
+		laddr := c.LocalAddr().(*net.TCPAddr)
+		if raddr.Port == laddr.Port && raddr.Zone == laddr.Zone && raddr.IP.Equal(laddr.IP) {
+			c.Close()
+			return nil, ErrDialSelf
+		}
+	}
+
 	// c = wrapConnWithRemoteAddr(c, netAddr)
 	return c, err
 }

--- a/interface.go
+++ b/interface.go
@@ -40,6 +40,9 @@ var ErrUnsupportedProtocol = errors.New("protocol not yet supported")
 // ErrReuseFailed is returned if a reuse attempt was unsuccessful.
 var ErrReuseFailed = errors.New("reuse failed")
 
+// ErrDialSelf is returned if we connect to our own source address.
+var ErrDialSelf = errors.New("dialed our own socket")
+
 // Listen listens at the given network and address. see net.Listen
 // Returns a net.Listener created from a file discriptor for a socket
 // with SO_REUSEPORT and SO_REUSEADDR option set.

--- a/reuse_test.go
+++ b/reuse_test.go
@@ -114,6 +114,17 @@ func TestStreamListenSamePort(t *testing.T) {
 	}
 }
 
+func TestDialSelf(t *testing.T) {
+	l, err := Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = Dial("tcp4", l.Addr().String(), l.Addr().String())
+	if err != ErrDialSelf {
+		t.Fatal("should have gotten an error for dialing self")
+	}
+}
+
 func TestPacketListenSamePort(t *testing.T) {
 
 	// any ports


### PR DESCRIPTION
Dialing oneself with reuseport enabled results in a loopback socket. This is totally useless and causes weird hard-to-debug problems so close it and return an error instead.