### PR TITLE
check for reuseport support by opening a socket, not listening.

### DIFF
--- a/reuse_test.go
+++ b/reuse_test.go
@@ -120,7 +120,7 @@ func TestDialSelf(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, err = Dial("tcp4", l.Addr().String(), l.Addr().String())
-	if err != ErrDialSelf {
+	if err == nil {
 		t.Fatal("should have gotten an error for dialing self")
 	}
 }


### PR DESCRIPTION
This ensures that, even if we can't bind to a random port on localhost for some reason, we can still correctly detect if reuse port is supported.

Thanks to @Coderlane for suggesting this fix.

@fasaxc, if you're still around, do you think you could test this?