### PR TITLE
Use syscall pkg for windows control file instead of windows pkg

### DIFF
--- a/control_windows.go
+++ b/control_windows.go
@@ -2,12 +2,10 @@ package reuseport
 
 import (
 	"syscall"
-
-	"golang.org/x/sys/windows"
 )
 
 func Control(network, address string, c syscall.RawConn) (err error) {
 	return c.Control(func(fd uintptr) {
-		err = windows.SetsockoptInt(windows.Handle(fd), windows.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
+		err = syscall.SetsockoptInt(syscall.Handle(fd), syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
 	})
 }


### PR DESCRIPTION
I don't know how much of an issue is this but as far as I can see syscall package includes all needed resources to define Control function for windows, so it can save an import there.