### PR TITLE
windows: use SO_REUSEADDR form sys/windows instead of from syscall

### DIFF
--- a/control_windows.go
+++ b/control_windows.go
@@ -8,6 +8,6 @@ import (
 
 func Control(network, address string, c syscall.RawConn) (err error) {
 	return c.Control(func(fd uintptr) {
-		err = windows.SetsockoptInt(windows.Handle(fd), windows.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
+		err = windows.SetsockoptInt(windows.Handle(fd), windows.SOL_SOCKET, windows.SO_REUSEADDR, 1)
 	})
 }


### PR DESCRIPTION
Some constants in syscall are wrong, IIRC, and I'd like to avoid it as much as possible.

Inverse of #62.