### PR TITLE
fix: add wasm build tag to wasm module

### DIFF
--- a/control_wasm.go
+++ b/control_wasm.go
@@ -1,3 +1,5 @@
+// +build wasm
+
 package reuseport
 
 import (


### PR DESCRIPTION
It is not strictly needed but in cases of builds with Go older than 1.11
it significantly improves error message.