### PR TITLE
Fix error discarding and clobbering in Control funcs

### DIFF
--- a/control_unix.go
+++ b/control_unix.go
@@ -8,18 +8,16 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func Control(network, address string, c syscall.RawConn) error {
-	var err error
-	c.Control(func(fd uintptr) {
+func Control(network, address string, c syscall.RawConn) (err error) {
+	controlErr := c.Control(func(fd uintptr) {
 		err = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEADDR, 1)
 		if err != nil {
 			return
 		}
-
 		err = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
-		if err != nil {
-			return
-		}
 	})
-	return err
+	if controlErr != nil {
+		err = controlErr
+	}
+	return
 }

--- a/control_windows.go
+++ b/control_windows.go
@@ -7,7 +7,11 @@ import (
 )
 
 func Control(network, address string, c syscall.RawConn) (err error) {
-	return c.Control(func(fd uintptr) {
+	controlErr := c.Control(func(fd uintptr) {
 		err = windows.SetsockoptInt(windows.Handle(fd), windows.SOL_SOCKET, windows.SO_REUSEADDR, 1)
 	})
+	if controlErr != nil {
+		err = controlErr
+	}
+	return
 }


### PR DESCRIPTION
Both sockopt and control errors can't exist at the same time, but control errors should occur first, and so are given precedence.

Fixes #101