### PR TITLE
chore: add pre-commit hook to perform gofmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,10 @@ Tested on `darwin`, `linux`, and `windows`.
 ---
 
 The last gx published version of this module was: 0.2.2: Qme8kdM7thoCqLqd7GYCRqipoZJS64rhJo5MBcTpyWfsL9
+
+## For contributors
+To enable the git hooks:
+
+```bash
+git config core.hooksPath hooks
+```

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+echo "Running pre commit hook"
+
+## this will retrieve all of the .go files that have been
+## changed since the last commit
+STAGED_GO_FILES=$(git diff --cached --name-only -- '*.go')
+
+## we can check to see if this is empty
+if [[ $STAGED_GO_FILES == "" ]]; then
+    echo "No Go Files to Update"
+else
+    for file in $STAGED_GO_FILES; do
+        ## format our file
+        go fmt $file
+        ## add any potential changes from our formatting to the
+        ## commit
+        git add $file
+    done
+fi
+


### PR DESCRIPTION
Git pre-commit hook to perform gofmt on all go files that are staged.

This would avoid contributors to wait for workflows to run in order to detect gofmt failures.